### PR TITLE
fix(vitepress): 修复并完善页面meta标签描述内容

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,7 +52,7 @@ const vitePressOptions = {
     
     // 生成页面标题和描述
     const pageTitle = frontmatter?.title || title
-    const pageDescription = frontmatter?.description || frontmatter?.description || 'don\'t worry, be happy.'
+    const pageDescription = frontmatter?.description || 'don\'t worry, be happy.'
     
     // 处理图片 URL：必须是绝对路径，微信才能抓取
     let pageImage = frontmatter?.image

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -103,7 +103,7 @@ watch(
           </div>
           <div v-if="$frontmatter.description"
             class="flex items-center p-3 rounded-lg text-sm font-medium bg-(--vp-c-bg-soft) text-(--vp-c-text-2)">
-            <span>{{ $frontmatter.description }}</span>
+            <span id="description">{{ $frontmatter.description }}</span>
           </div>
         </div>
       </div>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@nolebase/vitepress-plugin-git-changelog/client'
 import '@nolebase/vitepress-plugin-git-changelog/client/style.css'
 import { loadVercountScript, sendBaiduAnalyticsPageView, sendGoogleAnalyticsPageView } from './hooks/useVisitData'
+import { useData } from 'vitepress'
 
 const theme: Theme = {
   ...DefaultTheme,
@@ -19,9 +20,36 @@ const theme: Theme = {
         loadVercountScript()
         sendBaiduAnalyticsPageView(to)
         sendGoogleAnalyticsPageView(to)
+        
+        // 更新 meta 标签
+        updateMetaTags()
       }
     }
   },
 };
+
+// 更新 meta 标签的函数
+function updateMetaTags() {
+  const descriptionEl = document.getElementById('description')
+  const pageDescription = descriptionEl?.textContent || 'don\'t worry, be happy.'
+  
+  // 更新 Open Graph description
+  let ogDesc = document.querySelector('meta[property="og:description"]')
+  if (ogDesc) {
+    ogDesc.setAttribute('content', pageDescription)
+  }
+  
+  // 更新 Twitter description
+  let twitterDesc = document.querySelector('meta[name="twitter:description"]')
+  if (twitterDesc) {
+    twitterDesc.setAttribute('content', pageDescription)
+  }
+  
+  // 更新常规 description meta 标签
+  let metaDesc = document.querySelector('meta[name="description"]')
+  if (metaDesc) {
+    metaDesc.setAttribute('content', pageDescription)
+  }
+}
 
 export default theme;


### PR DESCRIPTION
1. 移除重复的默认描述代码冗余
2. 给页面描述元素添加id方便获取
3. 新增自动同步页面描述到各平台meta标签的功能